### PR TITLE
Refactor Arbitrum Local configuration in config.ts

### DIFF
--- a/src/common/config/config.ts
+++ b/src/common/config/config.ts
@@ -26,19 +26,19 @@ export default () => ({
       originBlock: 109913803, // First TX on CM contract.
       lastSyncedBlock: 0,
     },
-    {
-      name: 'Arbitrum Local',
-      rpcUrl: process.env.ARB_LOCAL_RPC,
-      rpcWssUrl: process.env.ARB_LOCAL_RPC_WSS,
-      fastSyncRpcUrl: process.env.ARB_LOCAL_FAST_SYNC_RPC,
-      chainId: 412346,
-      cacheManagerAddress: '0x0f1f89aaf1c6fdb7ff9d361e4388f5f3997f12a8',
-      arbWasmCacheAddress: '0x0000000000000000000000000000000000000072',
-      cacheManagerAutomationAddress:
-        '0x075C94dF4e30274A3fd38b0d13ef501Cc83542D6',
-      originBlock: 1,
-      lastSyncedBlock: 0,
-    },
+    // {
+    //   name: 'Arbitrum Local',
+    //   rpcUrl: process.env.ARB_LOCAL_RPC,
+    //   rpcWssUrl: process.env.ARB_LOCAL_RPC_WSS,
+    //   fastSyncRpcUrl: process.env.ARB_LOCAL_FAST_SYNC_RPC,
+    //   chainId: 412346,
+    //   cacheManagerAddress: '0x0f1f89aaf1c6fdb7ff9d361e4388f5f3997f12a8',
+    //   arbWasmCacheAddress: '0x0000000000000000000000000000000000000072',
+    //   cacheManagerAutomationAddress:
+    //     '0x075C94dF4e30274A3fd38b0d13ef501Cc83542D6',
+    //   originBlock: 1,
+    //   lastSyncedBlock: 0,
+    // },
   ],
   eventTypes: [
     // CacheManager


### PR DESCRIPTION
- Commented out the Arbitrum Local configuration block for clarity and to prevent potential misconfigurations.
- This change improves code readability and maintains focus on active configurations.