### PR TITLE
Add minBid property to processedContract in ContractsUtilsService

### DIFF
--- a/src/contracts/contracts.utils.service.ts
+++ b/src/contracts/contracts.utils.service.ts
@@ -570,6 +570,7 @@ export class ContractsUtilsService {
           userBalance: string;
         };
       }>;
+      minBid: string;
     }
   > {
     let processedContract: Contract & {
@@ -589,8 +590,10 @@ export class ContractsUtilsService {
         suggestedBids: BidRiskLevels;
         cacheStats: CacheStats;
       };
+      minBid: string;
     } = {
       ...contract,
+      minBid: '0',
     };
 
     // Only calculate effective bid and eviction risk if the contract is cached
@@ -603,6 +606,7 @@ export class ContractsUtilsService {
         ...processedContract,
         effectiveBid,
         evictionRisk,
+        minBid: evictionRisk.cacheStats.minBid,
       };
     } else {
       // If contract is not cached, only calculate suggested bids
@@ -615,6 +619,7 @@ export class ContractsUtilsService {
       processedContract = {
         ...processedContract,
         suggestedBids: { suggestedBids, cacheStats },
+        minBid: cacheStats.minBid,
       };
     }
 
@@ -674,6 +679,7 @@ export class ContractsUtilsService {
           userBalance: string;
         };
       }>;
+      minBid: string;
     })[]
   > {
     if (contracts.length === 0) {


### PR DESCRIPTION
## Changes

- Introduced minBid property to the processedContract object to track minimum bid values.

## Testing

![image](https://github.com/user-attachments/assets/e86aacfb-ed03-443e-984e-9c94ebccd0b3)
