### PR TITLE
Refactor alert notification timestamps

### DIFF
--- a/src/alerts/alerts.md
+++ b/src/alerts/alerts.md
@@ -77,7 +77,8 @@ The module exposes the following endpoints:
 - **userContract**: The contract being monitored
 - **user**: The user who owns the alert
 - **lastTriggered**: When the alert was last triggered
-- **lastNotified**: When a notification was last sent
+- **lastQueued**: When a notification was last queued
+- **lastNotified**: When a notification was succesfully sent
 - **triggeredCount**: How many times the alert has been triggered
 - **Notification Channels**: Flags for each supported notification channel
 

--- a/src/alerts/entities/alert.entity.ts
+++ b/src/alerts/entities/alert.entity.ts
@@ -29,6 +29,9 @@ export class Alert {
   @Column({ nullable: true })
   lastNotified: Date;
 
+  @Column({ nullable: true })
+  lastQueued: Date;
+
   @Column({ default: 0 })
   triggeredCount: number;
 

--- a/src/alerts/interfaces/alert-responses.interface.ts
+++ b/src/alerts/interfaces/alert-responses.interface.ts
@@ -15,6 +15,7 @@ export interface AlertResponse {
   value?: string;
   lastTriggered?: Date;
   lastNotified?: Date;
+  lastQueued?: Date;
 }
 
 /**

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -74,7 +74,7 @@ export class NotificationsService {
     );
 
     // Update lastQueued timestamp
-    const updatedAlert = this.timingService.updatelastQueued(alert);
+    const updatedAlert = this.timingService.updateLastQueued(alert);
     await this.alertsRepository.save(updatedAlert);
   }
 

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -73,8 +73,8 @@ export class NotificationsService {
       `Successfully queued ${queuedCount} notifications for alert: ${alert.id}`,
     );
 
-    // Update lastNotified timestamp
-    const updatedAlert = this.timingService.updateLastNotified(alert);
+    // Update lastQueued timestamp
+    const updatedAlert = this.timingService.updatelastQueued(alert);
     await this.alertsRepository.save(updatedAlert);
   }
 

--- a/src/notifications/processors/telegram.processor.ts
+++ b/src/notifications/processors/telegram.processor.ts
@@ -6,6 +6,7 @@ import { Alert } from 'src/alerts/entities/alert.entity';
 import { TelegramNotificationService } from '../services/telegram.service';
 import { BaseProcessorData } from '../interfaces';
 import { createContextLogger } from 'src/common/utils/logger.util';
+import { TimingService } from '../services/timing.service';
 
 @Processor('notif-telegram')
 export class TelegramNotificationProcessor extends WorkerHost {
@@ -18,6 +19,7 @@ export class TelegramNotificationProcessor extends WorkerHost {
     private readonly telegramService: TelegramNotificationService,
     @InjectRepository(Alert)
     private alertsRepository: Repository<Alert>,
+    private readonly timingService: TimingService,
   ) {
     super();
   }
@@ -54,6 +56,10 @@ export class TelegramNotificationProcessor extends WorkerHost {
         contractName: alert.userContract?.name || 'Unknown Contract',
         contractAddress: alert.userContract?.address || 'Unknown Address',
       });
+
+      // Update lastNotified timestamp
+      const updatedAlert = this.timingService.updateLastNotified(alert);
+      await this.alertsRepository.save(updatedAlert);
 
       this.logger.log(
         `Successfully sent Telegram notification for alert: ${alertId}`,

--- a/src/notifications/services/timing.service.ts
+++ b/src/notifications/services/timing.service.ts
@@ -11,7 +11,7 @@ export class TimingService {
    * Check if the backoff delay has been exceeded since the last notification
    */
   isBackoffDelayExceeded(alert: Alert): boolean {
-    if (!alert.lastNotified) {
+    if (!alert.lastQueued) {
       this.logger.debug(
         `No previous notification for alert: ${alert.id} - allowing notification`,
       );
@@ -19,9 +19,9 @@ export class TimingService {
     }
 
     const backoffDelay = process.env.BACKOFF_DELAY;
-    const lastNotified = new Date(alert.lastNotified);
+    const lastQueued = new Date(alert.lastQueued);
     const now = new Date();
-    const timeDiff = now.getTime() - lastNotified.getTime();
+    const timeDiff = now.getTime() - lastQueued.getTime();
 
     const delayExceeded = timeDiff >= Number(backoffDelay);
 
@@ -42,8 +42,14 @@ export class TimingService {
   }
 
   /**
-   * Update the lastNotified timestamp for an alert
+   * Update the lastQueued timestamp for an alert
    */
+  updatelastQueued(alert: Alert): Alert {
+    this.logger.debug(`Updating lastQueued timestamp for alert: ${alert.id}`);
+    alert.lastQueued = new Date();
+    return alert;
+  }
+
   updateLastNotified(alert: Alert): Alert {
     this.logger.debug(`Updating lastNotified timestamp for alert: ${alert.id}`);
     alert.lastNotified = new Date();


### PR DESCRIPTION
- Added `lastQueued` property to the Alert entity to track when notifications are queued.
- Updated relevant interfaces and services to accommodate the new `lastQueued` timestamp.
- Modified notification processors to update `lastQueued` instead of `lastNotified` when notifications are sent.
- Adjusted timing service logic to utilize `lastQueued` for backoff delay checks.