### PR TITLE
Allow local frontends in non-production CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,8 @@ REDIS_HOST=scm-redis
 REDIS_PORT=6379
 
 # CORS
-# For Develop and Staging Environments. Allows all preview frontends to access.
+# For Develop and Staging Environments. Comma-separated origin prefixes.
+# HTTP localhost and 127.0.0.1 origins are automatically allowed outside production.
 ALLOWED_ORIGIN_PREFIX=https://stylus-cm-frontend
 
 # For production. Only allows one origin.

--- a/src/common/config/app.config.spec.ts
+++ b/src/common/config/app.config.spec.ts
@@ -1,0 +1,106 @@
+import { LogLevel } from '@nestjs/common';
+import appConfig, { AppConfig, shouldAllowOrigin } from './app.config';
+
+const createConfig = (overrides: Partial<AppConfig> = {}): AppConfig => ({
+  environment: 'staging',
+  port: 3000,
+  loggerLevels: ['log'] as LogLevel[],
+  allowedOriginPrefixes: [],
+  cors: {
+    allowedHttpMethods: ['GET'],
+  },
+  ...overrides,
+});
+
+describe('appConfig', () => {
+  const originalAllowedOriginPrefix = process.env.ALLOWED_ORIGIN_PREFIX;
+
+  afterEach(() => {
+    if (originalAllowedOriginPrefix === undefined) {
+      delete process.env.ALLOWED_ORIGIN_PREFIX;
+      return;
+    }
+
+    process.env.ALLOWED_ORIGIN_PREFIX = originalAllowedOriginPrefix;
+  });
+
+  it('parses comma-separated origin prefixes', () => {
+    process.env.ALLOWED_ORIGIN_PREFIX =
+      'https://stylus-cm-frontend, http://localhost, http://127.0.0.1';
+
+    expect(appConfig().allowedOriginPrefixes).toEqual([
+      'https://stylus-cm-frontend',
+      'http://localhost',
+      'http://127.0.0.1',
+    ]);
+  });
+});
+
+describe('shouldAllowOrigin', () => {
+  it('allows local HTTP origins in non-production environments', () => {
+    expect(shouldAllowOrigin('http://localhost:3001', createConfig())).toBe(
+      true,
+    );
+    expect(shouldAllowOrigin('http://127.0.0.1:5173', createConfig())).toBe(
+      true,
+    );
+  });
+
+  it('does not allow local origins in production', () => {
+    const config = createConfig({ environment: 'production' });
+
+    expect(shouldAllowOrigin('http://localhost:3001', config)).toBe(false);
+    expect(shouldAllowOrigin('http://127.0.0.1:5173', config)).toBe(false);
+  });
+
+  it('does not treat lookalike or HTTPS hosts as local HTTP origins', () => {
+    expect(
+      shouldAllowOrigin('http://localhost.example.com:3001', createConfig()),
+    ).toBe(false);
+    expect(shouldAllowOrigin('https://localhost:3001', createConfig())).toBe(
+      false,
+    );
+  });
+
+  it('allows an origin matching any configured prefix', () => {
+    const config = createConfig({
+      allowedOriginPrefixes: ['https://stylus-cm-frontend', 'http://localhost'],
+    });
+
+    expect(shouldAllowOrigin('http://localhost:3001', config)).toBe(true);
+    expect(
+      shouldAllowOrigin(
+        'https://stylus-cm-frontend-preview.vercel.app',
+        config,
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects an origin that does not match a configured prefix', () => {
+    const config = createConfig({
+      allowedOriginPrefixes: ['https://stylus-cm-frontend'],
+    });
+
+    expect(shouldAllowOrigin('https://example.com', config)).toBe(false);
+  });
+
+  it('allows the exact configured frontend URL', () => {
+    const config = createConfig({
+      frontendUrl: 'https://stylus-cm-frontend-staging.vercel.app',
+    });
+
+    expect(
+      shouldAllowOrigin(
+        'https://stylus-cm-frontend-staging.vercel.app',
+        config,
+      ),
+    ).toBe(true);
+  });
+
+  it('allows requests without an origin only in local environments', () => {
+    expect(
+      shouldAllowOrigin(undefined, createConfig({ environment: 'local' })),
+    ).toBe(true);
+    expect(shouldAllowOrigin(undefined, createConfig())).toBe(false);
+  });
+});

--- a/src/common/config/app.config.ts
+++ b/src/common/config/app.config.ts
@@ -16,7 +16,7 @@ export interface AppConfig {
   environment: 'local' | 'develop' | 'staging' | 'production';
   loggerLevels: LogLevel[];
   port: number;
-  allowedOriginPrefix?: string;
+  allowedOriginPrefixes: string[];
   frontendUrl?: string;
 }
 
@@ -53,7 +53,10 @@ export default registerAs('app', (): AppConfig => {
     ? validatePort(process.env.PORT, 'PORT')
     : DEFAULT_PORT;
   const frontendUrl = process.env.FRONTEND_URL;
-  const allowedOriginPrefix = process.env.ALLOWED_ORIGIN_PREFIX;
+  const allowedOriginPrefixes = (process.env.ALLOWED_ORIGIN_PREFIX || '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
 
   // Parse logger levels from environment variable
   const loggerLevels = process.env.LOGGER_LEVELS
@@ -64,7 +67,7 @@ export default registerAs('app', (): AppConfig => {
     environment,
     port,
     frontendUrl,
-    allowedOriginPrefix,
+    allowedOriginPrefixes,
     loggerLevels,
     cors: {
       allowedHttpMethods: ALLOWED_HTTP_METHODS,
@@ -82,11 +85,16 @@ export function shouldAllowOrigin(
     return true;
   }
 
+  // Allow local frontends to use non-production backends.
+  if (config.environment !== 'production' && isLocalHttpOrigin(origin)) {
+    return true;
+  }
+
   // Allow origins that start with the configured prefix in non-production
   if (
     config.environment !== 'production' &&
-    config.allowedOriginPrefix &&
-    origin?.startsWith(config.allowedOriginPrefix)
+    origin &&
+    config.allowedOriginPrefixes.some((prefix) => origin.startsWith(prefix))
   ) {
     return true;
   }
@@ -97,4 +105,20 @@ export function shouldAllowOrigin(
   }
 
   return false;
+}
+
+function isLocalHttpOrigin(origin: string | undefined): boolean {
+  if (!origin) {
+    return false;
+  }
+
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === 'http:' &&
+      (url.hostname === 'localhost' || url.hostname === '127.0.0.1')
+    );
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- allow HTTP localhost and 127.0.0.1 origins in non-production environments
- parse comma-separated ALLOWED_ORIGIN_PREFIX values correctly
- document the non-production localhost behavior
- add CORS configuration regression tests

## Verification
- npm test -- --runInBand common/config/app.config.spec.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded CORS configuration to support multiple allowed origin prefixes.
  * Automatically allows local HTTP origins outside production environments.
  * Updated environment configuration guidance for origin prefixes and engine authentication tokens.

* **Bug Fixes**
  * Improved origin validation for production, preview, local, and unmatched origins.

* **Tests**
  * Added coverage for CORS parsing and origin-allowance behavior across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->